### PR TITLE
Fix redhat source location and maven settings

### DIFF
--- a/build-eap.sh
+++ b/build-eap.sh
@@ -7,7 +7,7 @@ set_version $1
 make_directory -f work
 make_directory download
 make_directory dist
-download_and_unzip http://ftp.redhat.com/redhat/jbeap/$EAP_VERSION/en/source/$SRC_FILE
+download_and_unzip http://ftp.redhat.com/redhat/jboss/eap/$EAP_VERSION/en/source/$SRC_FILE
 patch_files
 build_core
 maven_build

--- a/src/settings.xml
+++ b/src/settings.xml
@@ -17,7 +17,7 @@
         <repository>
           <id>central</id>
           <name>Use unique IDs for downloading artifacts vs. plugins from central</name>
-          <url>http://repo1.maven.org/maven2</url>
+          <url>https://repo1.maven.org/maven2</url>
           <releases>
             <enabled>true</enabled>
             <updatePolicy>never</updatePolicy>
@@ -29,7 +29,7 @@
         <repository>
           <id>jboss-public-repo</id>
           <name>JBoss Public Repository Group</name>
-          <url>http://repository.jboss.org/nexus/content/groups/public/</url>
+          <url>https://repository.jboss.org/nexus/content/groups/public/</url>
           <layout>default</layout>
           <releases>
             <enabled>true</enabled>


### PR DESCRIPTION
The url for jboss source changed recently-ish. Updated to the new
structure.

Updated the maven settings file to use https, which is now required by
maven central.